### PR TITLE
Fix digest authentication

### DIFF
--- a/WebSocket/WebSocketHTTPLogic.m
+++ b/WebSocket/WebSocketHTTPLogic.m
@@ -119,7 +119,7 @@
             Assert(CFHTTPMessageAddAuthentication(httpMsg, _responseMsg,
                                                   (__bridge CFStringRef)_credential.user,
                                                   (__bridge CFStringRef)password,
-                                                  kCFHTTPAuthenticationSchemeBasic,
+                                                  NULL,
                                                   _httpStatus == 407));
         } else {
             Warn(@"%@: Unable to get password of credential %@", self, _credential);


### PR DESCRIPTION
Set authentication scheme of CFHTTPMessageAddAuthentication() call to NULL which allows the authentication scheme to be set based on authenticationFailureResponse.

https://github.com/couchbase/couchbase-lite-ios/issues/777
